### PR TITLE
Track feditest / pre-create-constellation

### DIFF
--- a/Makefile.generate
+++ b/Makefile.generate
@@ -1,0 +1,128 @@
+#
+# This Makefile regenerates session template files and test plan files.
+# The generated files are also checked-in, so new users can get started quickly.
+#
+# This attempt to run executable `feditest` in your $PATH. If you'd like
+# to run a different executable, such as one in a virtual environment,
+# invoke this Makefile with extra parameter FEDITEST=path/to/my/feditest
+#
+
+FEDITEST=feditest
+
+default : all
+
+all : examples
+
+examples : \
+  examples-session-templates \
+  examples-constellations \
+  examples-testplans
+
+
+########## Example session templates ##########
+
+examples-session-templates : \
+  examples/session-templates/sandbox-all.json \
+  examples/session-templates/internal-all.json
+
+examples/session-templates/sandbox-all.json : \
+  tests/sandbox/*.py
+	$(FEDITEST) generate-session-template \
+		--name 'All sandbox tests' \
+		--filter 'sandbox' \
+		--out $@
+
+examples/session-templates/internal-all.json : \
+  tests/internal/*.py
+	$(FEDITEST) generate-session-template \
+		--name 'Internal all' \
+		--filter 'internal' \
+		--out $@
+
+
+##### Example constellations ##########
+
+examples-constellations : \
+  examples/constellations/clientA-vs-server1.json \
+  examples/constellations/clientA-vs-server2faulty.json \
+  examples/constellations/degenerate-empty.json
+
+examples/constellations/clientA-vs-server1.json : \
+  examples/nodes/clientA.json \
+  examples/nodes/server1.json
+	$(FEDITEST) create-constellation \
+		--name 'clientA vs server1' \
+		--node client=examples/nodes/clientA.json \
+		--node server=examples/nodes/server1.json \
+		--out $@
+
+examples/constellations/clientA-vs-server2faulty.json : \
+  examples/nodes/clientA.json \
+  examples/nodes/server2faulty.json
+	$(FEDITEST) create-constellation \
+		--name 'clientA vs server2faulty' \
+		--node client=examples/nodes/clientA.json \
+		--node server=examples/nodes/server2faulty.json \
+		--out $@
+
+examples/constellations/degenerate-empty.json :
+	echo '{\n    "name" : "empty-for-internal-tests-only",\n    "roles" : {}\n}' > $@
+
+
+#### Example test plans ##########
+
+examples-testplans : \
+  examples/testplans/sandbox-all-clientA-vs-server1.json \
+  examples/testplans/sandbox-all-clientA-vs-server2faulty.json \
+  examples/testplans/sandbox-all-clientA-vs-both-server1-server2faulty.json \
+  examples/testplans/internal-all.json
+
+examples/testplans/sandbox-all-clientA-vs-server1.json : \
+  examples/session-templates/sandbox-all.json \
+  examples/constellations/clientA-vs-server1.json
+	$(FEDITEST) generate-testplan \
+		--name 'All sandbox tests running clientA against server1' \
+		--session-template examples/session-templates/sandbox-all.json \
+		--constellation examples/constellations/clientA-vs-server1.json \
+		--out $@
+
+examples/testplans/sandbox-all-clientA-vs-server2faulty.json : \
+  examples/session-templates/sandbox-all.json \
+  examples/constellations/clientA-vs-server2faulty.json
+	$(FEDITEST) generate-testplan \
+		--name 'All sandbox tests running clientA against faulty server2' \
+		--session-template examples/session-templates/sandbox-all.json \
+		--constellation examples/constellations/clientA-vs-server2faulty.json \
+		--out $@
+
+examples/testplans/sandbox-all-clientA-vs-both-server1-server2faulty.json : \
+  examples/session-templates/sandbox-all.json \
+  examples/constellations/clientA-vs-server1.json \
+  examples/constellations/clientA-vs-server2faulty.json
+	$(FEDITEST) generate-testplan \
+		--name 'All sandbox tests running clientA against both server1 and then faulty server2' \
+		--session-template examples/session-templates/sandbox-all.json \
+		--constellation examples/constellations/clientA-vs-server1.json examples/constellations/clientA-vs-server2faulty.json \
+		--out $@
+
+
+examples/testplans/internal-all.json : \
+  examples/session-templates/internal-all.json \
+  examples/constellations/degenerate-empty.json
+	$(FEDITEST) generate-testplan \
+		--name 'All internal tests' \
+		--session-template examples/session-templates/internal-all.json \
+		--constellation examples/constellations/degenerate-empty.json \
+		--out $@
+
+
+########## and the rest ##########
+
+clean :
+	rm examples/{session-templates,constellations,testplans}/*.json
+
+
+.PHONY : \
+  default all clean \
+  examples examples-session-templates examples-constellations examples-testplans
+

--- a/Makefile.generate
+++ b/Makefile.generate
@@ -119,7 +119,7 @@ examples/testplans/internal-all.json : \
 ########## and the rest ##########
 
 clean :
-	rm examples/{session-templates,constellations,testplans}/*.json
+	-rm examples/{session-templates,constellations,testplans}/*.json
 
 
 .PHONY : \

--- a/Makefile.run
+++ b/Makefile.run
@@ -85,7 +85,7 @@ examples/testresults/%.json : examples/testplans/%.json
 ########## and the rest ##########
 
 clean :
-	rm examples/testresults/*.{json,tap,html}
+	-rm examples/testresults/*.{json,tap,html}
 
 
 .PHONY : \

--- a/Makefile.run
+++ b/Makefile.run
@@ -1,0 +1,95 @@
+#
+# This Makefile runs certain test plans
+#
+# This attempt to run executable `feditest` in your $PATH. If you'd like
+# to run a different executable, such as one in a virtual environment,
+# invoke this Makefile with extra parameter FEDITEST=path/to/my/feditest
+#
+
+FEDITEST=feditest
+
+SANDBOX_TESTPLANS= \
+  sandbox-all-clientA-vs-server1 \
+  sandbox-all-clientA-vs-server2faulty \
+  sandbox-all-clientA-vs-both-server1-server2faulty
+
+INTERNAL_TESTPLANS= \
+  internal-all
+
+default : sandbox
+
+all : \
+  sandbox \
+  internal
+
+sandbox : \
+  sandbox-transcripts \
+  sandbox-transcripts-tap \
+  sandbox-transcripts-html
+
+sandbox-transcripts : \
+  $(patsubst %, examples/testresults/%.json, $(SANDBOX_TESTPLANS))
+
+sandbox-transcripts-tap : \
+  $(patsubst %, examples/testresults/%.tap, $(SANDBOX_TESTPLANS))
+
+sandbox-transcripts-html : \
+  $(patsubst %, examples/testresults/%.sequential.html, $(SANDBOX_TESTPLANS)) \
+  $(patsubst %, examples/testresults/%.testmatrix.html, $(SANDBOX_TESTPLANS))
+
+internal : \
+  internal-transcripts \
+  internal-transcripts-tap \
+  internal-transcripts-html
+
+internal-transcripts : \
+  $(patsubst %, examples/testresults/%.json, $(INTERNAL_TESTPLANS))
+
+internal-transcripts-tap : \
+  $(patsubst %, examples/testresults/%.tap, $(INTERNAL_TESTPLANS))
+
+internal-transcripts-html : \
+  $(patsubst %, examples/testresults/%.sequential.html, $(INTERNAL_TESTPLANS)) \
+  $(patsubst %, examples/testresults/%.testmatrix.html, $(INTERNAL_TESTPLANS))
+
+
+########## General rules to make things simpler ##########
+
+# Given a testplan in examples/testplans, run it and generate a testrun JSON transcript in examples/testresults with the same name
+examples/testresults/%.json : examples/testplans/%.json
+	$(FEDITEST) run \
+		--testplan $< \
+		--json $@ \
+	|| echo 'ERRORS in the test run (as expected), so we continue'
+
+# Given a testrun JSON transcript, convert it to TAP format
+%.tap : %.json
+	$(FEDITEST) convert-transcript \
+		--in $< \
+		--tap $@
+
+# Given a testrun JSON transcript, convert it to HTML format with a template that lists everything that happened in sequential order
+%.sequential.html : %.json
+	$(FEDITEST) convert-transcript \
+		--in $< \
+		--html $@ \
+		--template testrun-report-sequential-standalone
+
+# Given a testrun JSON transcript, convert it to HTML format with a template that creates a test matrix
+%.testmatrix.html : %.json
+	$(FEDITEST) convert-transcript \
+		--in $< \
+		--html $@ \
+		--template testrun-report-testmatrix-standalone
+
+########## and the rest ##########
+
+clean :
+	rm examples/testresults/*.{json,tap,html}
+
+
+.PHONY : \
+  default all clean \
+  sandbox sandbox-transcript sandbox-transcripts-tap sandbox-transcripts-html \
+  internal internal-transcript internal-transcripts-tap internal-transcripts-html
+

--- a/examples/nodes/clientA.json
+++ b/examples/nodes/clientA.json
@@ -1,0 +1,3 @@
+{
+    "nodedriver" : "sandbox.SandboxMultClientDriver_ImplementationA"
+}

--- a/examples/nodes/server1.json
+++ b/examples/nodes/server1.json
@@ -1,0 +1,3 @@
+{
+    "nodedriver" : "sandbox.SandboxMultServerDriver_Implementation1"
+}

--- a/examples/nodes/server2faulty.json
+++ b/examples/nodes/server2faulty.json
@@ -1,0 +1,3 @@
+{
+    "nodedriver" : "sandbox.SandboxMultServerDriver_Implementation2Faulty"
+}


### PR DESCRIPTION
Part 1 of reorganzing test plans and their creation: all now in examples/ directory, and what can be generated automatically is with Makefile.{generate,run}

Part 2 (not yet) is removing the directories (like ./constellations) that we don't need any more