### PR TITLE
Make it easier to run make targets with different versions of feditest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+examples.*/

--- a/Makefile.generate
+++ b/Makefile.generate
@@ -8,31 +8,37 @@
 #
 
 FEDITEST=feditest
+Q=
+# Could set from the command-line to something like: 'Q=.$(shell git branch --show-current)'
+
+EX=examples$(Q)
 
 default : clean all
 
-all : examples
+all : $(EX)
 
-examples : \
-  examples-session-templates \
-  examples-constellations \
-  examples-testplans
+$(EX) : \
+  $(EX)-session-templates \
+  $(EX)-constellations \
+  $(EX)-testplans
 
 
 ########## Example session templates ##########
 
-examples-session-templates : \
-  examples/session-templates/sandbox-all.json \
-  examples/session-templates/internal-all.json
+$(EX)-session-templates : \
+  $(EX)/session-templates/sandbox-all.json \
+  $(EX)/session-templates/internal-all.json
 
-examples/session-templates/sandbox-all.json : \
+$(EX)/session-templates/sandbox-all.json : \
+  dirs \
   tests/sandbox/*.py
 	$(FEDITEST) generate-session-template \
 		--name 'All sandbox tests' \
 		--filter 'sandbox' \
 		--out $@
 
-examples/session-templates/internal-all.json : \
+$(EX)/session-templates/internal-all.json : \
+  dirs \
   tests/internal/*.py
 	$(FEDITEST) generate-session-template \
 		--name 'Internal all' \
@@ -42,12 +48,13 @@ examples/session-templates/internal-all.json : \
 
 ##### Example constellations ##########
 
-examples-constellations : \
-  examples/constellations/clientA-vs-server1.json \
-  examples/constellations/clientA-vs-server2faulty.json \
-  examples/constellations/degenerate-empty.json
+$(EX)-constellations : \
+  $(EX)/constellations/clientA-vs-server1.json \
+  $(EX)/constellations/clientA-vs-server2faulty.json \
+  $(EX)/constellations/degenerate-empty.json
 
-examples/constellations/clientA-vs-server1.json : \
+$(EX)/constellations/clientA-vs-server1.json : \
+  dirs \
   examples/nodes/clientA.json \
   examples/nodes/server1.json
 	$(FEDITEST) create-constellation \
@@ -56,7 +63,8 @@ examples/constellations/clientA-vs-server1.json : \
 		--node server=examples/nodes/server1.json \
 		--out $@
 
-examples/constellations/clientA-vs-server2faulty.json : \
+$(EX)/constellations/clientA-vs-server2faulty.json : \
+  dirs \
   examples/nodes/clientA.json \
   examples/nodes/server2faulty.json
 	$(FEDITEST) create-constellation \
@@ -65,64 +73,75 @@ examples/constellations/clientA-vs-server2faulty.json : \
 		--node server=examples/nodes/server2faulty.json \
 		--out $@
 
-examples/constellations/degenerate-empty.json :
+$(EX)/constellations/degenerate-empty.json : \
+  dirs
 	echo '{\n    "name" : "Empty (for internal tests only)",\n    "roles" : {}\n}' > $@
 
 
 #### Example test plans ##########
 
-examples-testplans : \
-  examples/testplans/sandbox-all-clientA-vs-server1.json \
-  examples/testplans/sandbox-all-clientA-vs-server2faulty.json \
-  examples/testplans/sandbox-all-clientA-vs-both-server1-server2faulty.json \
-  examples/testplans/internal-all.json
+$(EX)-testplans : \
+  $(EX)/testplans/sandbox-all-clientA-vs-server1.json \
+  $(EX)/testplans/sandbox-all-clientA-vs-server2faulty.json \
+  $(EX)/testplans/sandbox-all-clientA-vs-both-server1-server2faulty.json \
+  $(EX)/testplans/internal-all.json
 
-examples/testplans/sandbox-all-clientA-vs-server1.json : \
-  examples/session-templates/sandbox-all.json \
-  examples/constellations/clientA-vs-server1.json
+$(EX)/testplans/sandbox-all-clientA-vs-server1.json : \
+  dirs \
+  $(EX)/session-templates/sandbox-all.json \
+  $(EX)/constellations/clientA-vs-server1.json
 	$(FEDITEST) generate-testplan \
 		--name 'All sandbox tests running clientA against server1' \
-		--session-template examples/session-templates/sandbox-all.json \
-		--constellation examples/constellations/clientA-vs-server1.json \
+		--session-template $(EX)/session-templates/sandbox-all.json \
+		--constellation $(EX)/constellations/clientA-vs-server1.json \
 		--out $@
 
-examples/testplans/sandbox-all-clientA-vs-server2faulty.json : \
-  examples/session-templates/sandbox-all.json \
-  examples/constellations/clientA-vs-server2faulty.json
+$(EX)/testplans/sandbox-all-clientA-vs-server2faulty.json : \
+  dirs \
+  $(EX)/session-templates/sandbox-all.json \
+  $(EX)/constellations/clientA-vs-server2faulty.json
 	$(FEDITEST) generate-testplan \
 		--name 'All sandbox tests running clientA against faulty server2' \
-		--session-template examples/session-templates/sandbox-all.json \
-		--constellation examples/constellations/clientA-vs-server2faulty.json \
+		--session-template $(EX)/session-templates/sandbox-all.json \
+		--constellation $(EX)/constellations/clientA-vs-server2faulty.json \
 		--out $@
 
-examples/testplans/sandbox-all-clientA-vs-both-server1-server2faulty.json : \
-  examples/session-templates/sandbox-all.json \
-  examples/constellations/clientA-vs-server1.json \
-  examples/constellations/clientA-vs-server2faulty.json
+$(EX)/testplans/sandbox-all-clientA-vs-both-server1-server2faulty.json : \
+  dirs \
+  $(EX)/session-templates/sandbox-all.json \
+  $(EX)/constellations/clientA-vs-server1.json \
+  $(EX)/constellations/clientA-vs-server2faulty.json
 	$(FEDITEST) generate-testplan \
 		--name 'All sandbox tests running clientA against both server1 and then faulty server2' \
-		--session-template examples/session-templates/sandbox-all.json \
-		--constellation examples/constellations/clientA-vs-server1.json examples/constellations/clientA-vs-server2faulty.json \
+		--session-template $(EX)/session-templates/sandbox-all.json \
+		--constellation $(EX)/constellations/clientA-vs-server1.json $(EX)/constellations/clientA-vs-server2faulty.json \
 		--out $@
 
 
-examples/testplans/internal-all.json : \
-  examples/session-templates/internal-all.json \
-  examples/constellations/degenerate-empty.json
+$(EX)/testplans/internal-all.json : \
+  dirs \
+  $(EX)/session-templates/internal-all.json \
+  $(EX)/constellations/degenerate-empty.json
 	$(FEDITEST) generate-testplan \
 		--name 'All internal tests' \
-		--session-template examples/session-templates/internal-all.json \
-		--constellation examples/constellations/degenerate-empty.json \
+		--session-template $(EX)/session-templates/internal-all.json \
+		--constellation $(EX)/constellations/degenerate-empty.json \
 		--out $@
 
 
 ########## and the rest ##########
 
+dirs:
+	[[ -d $(EX)/session-templates ]] || mkdir -p $(EX)/session-templates
+	[[ -d $(EX)/constellations ]] || mkdir -p $(EX)/constellations
+	[[ -d $(EX)/testplans ]] || mkdir -p $(EX)/testplans
+
+
 clean :
-	-rm examples/{session-templates,constellations,testplans}/*.json >/dev/null 2>&1
+	-rm $(EX)/{session-templates,constellations,testplans}/*.json >/dev/null 2>&1
 
 
 .PHONY : \
-  default all clean \
-  examples examples-session-templates examples-constellations examples-testplans
+  default all dirs clean \
+  $(EX) $(EX)-session-templates $(EX)-constellations $(EX)-testplans
 

--- a/Makefile.run
+++ b/Makefile.run
@@ -7,6 +7,10 @@
 #
 
 FEDITEST=feditest
+Q=
+# Could set from the command-line to something like: 'Q=.$(shell git branch --show-current)'
+
+EX=examples$(Q)
 
 SANDBOX_TESTPLANS= \
   sandbox-all-clientA-vs-server1 \
@@ -28,14 +32,14 @@ sandbox : \
   sandbox-transcripts-html
 
 sandbox-transcripts : \
-  $(patsubst %, examples/testresults/%.json, $(SANDBOX_TESTPLANS))
+  $(patsubst %, $(EX)/testresults/%.json, $(SANDBOX_TESTPLANS))
 
 sandbox-transcripts-tap : \
-  $(patsubst %, examples/testresults/%.tap, $(SANDBOX_TESTPLANS))
+  $(patsubst %, $(EX)/testresults/%.tap, $(SANDBOX_TESTPLANS))
 
 sandbox-transcripts-html : \
-  $(patsubst %, examples/testresults/%.sequential.html, $(SANDBOX_TESTPLANS)) \
-  $(patsubst %, examples/testresults/%.testmatrix.html, $(SANDBOX_TESTPLANS))
+  $(patsubst %, $(EX)/testresults/%.sequential.html, $(SANDBOX_TESTPLANS)) \
+  $(patsubst %, $(EX)/testresults/%.testmatrix.html, $(SANDBOX_TESTPLANS))
 
 internal : \
   internal-transcripts \
@@ -43,20 +47,20 @@ internal : \
   internal-transcripts-html
 
 internal-transcripts : \
-  $(patsubst %, examples/testresults/%.json, $(INTERNAL_TESTPLANS))
+  $(patsubst %, $(EX)/testresults/%.json, $(INTERNAL_TESTPLANS))
 
 internal-transcripts-tap : \
-  $(patsubst %, examples/testresults/%.tap, $(INTERNAL_TESTPLANS))
+  $(patsubst %, $(EX)/testresults/%.tap, $(INTERNAL_TESTPLANS))
 
 internal-transcripts-html : \
-  $(patsubst %, examples/testresults/%.sequential.html, $(INTERNAL_TESTPLANS)) \
-  $(patsubst %, examples/testresults/%.testmatrix.html, $(INTERNAL_TESTPLANS))
+  $(patsubst %, $(EX)/testresults/%.sequential.html, $(INTERNAL_TESTPLANS)) \
+  $(patsubst %, $(EX)/testresults/%.testmatrix.html, $(INTERNAL_TESTPLANS))
 
 
 ########## General rules to make things simpler ##########
 
-# Given a testplan in examples/testplans, run it and generate a testrun JSON transcript in examples/testresults with the same name
-examples/testresults/%.json : examples/testplans/%.json
+# Given a testplan in $(EX)/testplans, run it and generate a testrun JSON transcript in $(EX)/testresults with the same name
+$(EX)/testresults/%.json : $(EX)/testplans/%.json dirs
 	$(FEDITEST) run \
 		--testplan $< \
 		--json $@ \
@@ -84,12 +88,15 @@ examples/testresults/%.json : examples/testplans/%.json
 
 ########## and the rest ##########
 
+dirs:
+	[[ -d $(EX)/testresults ]] || mkdir -p $(EX)/testresults
+
 clean :
-	-rm examples/testresults/*.{json,tap,html} >/dev/null 2>&1
+	-rm $(EX)/testresults/*.{json,tap,html} >/dev/null 2>&1
 
 
 .PHONY : \
-  default all clean \
+  default all dirs clean \
   sandbox sandbox-transcript sandbox-transcripts-tap sandbox-transcripts-html \
   internal internal-transcript internal-transcripts-tap internal-transcripts-html
 


### PR DESCRIPTION
Same as https://github.com/fediverse-devnet/feditest-tests-fediverse/pull/96: make it easier to run make targets with different versions of feditest